### PR TITLE
misc cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
+    "clean:project": "npm prune && npm cache clear && npm install",
     "compile": "better-npm-run compile",
     "lint": "eslint bin build config server src tests",
     "lint:fix": "npm run lint -- --fix",
@@ -128,14 +129,13 @@
     "react-dom": "^15.3.2",
     "react-hot-loader": "^3.0.0-beta.5",
     "react-redux": "^4.0.0",
-    "react-router": "3.0.0-beta.1",
+    "react-router": "^2.8.1",
     "redux": "^3.6.0",
     "redux-form": "^6.0.5",
-    "redux-socket-cluster": "^0.9.2",
     "redux-thunk": "^2.0.0",
     "rimraf": "^2.5.1",
     "shortid": "^2.2.6",
-    "socketcluster-client": "^5.0.10",
+    "socketcluster-client": "^5.0.13",
     "style-loader": "^0.13.0",
     "sugarss": "^0.1.6",
     "url-loader": "^0.5.6",
@@ -144,7 +144,7 @@
   },
   "peerDependencies": {
     "cheerio": "^0.22.0",
-    "socketcluster-client": "5.0.10"
+    "socketcluster-client": "^5.0.10"
   },
   "devDependencies": {
     "@kadira/storybook": "^2.19.0",

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,8 @@ const debug = _debug('app:server:express')
 const app = express()
 const paths = config.utils_paths
 
+require('events').EventEmitter.prototype._maxListeners = 100;
+
 // This rewrites all routes requests to the root /index.html file
 // (ignoring file requests). If you want to implement universal
 // rendering, you'll want to remove this middleware.

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,7 @@ const debug = _debug('app:server:express')
 const app = express()
 const paths = config.utils_paths
 
-require('events').EventEmitter.prototype._maxListeners = 100;
+require('events').EventEmitter.prototype._maxListeners = 100
 
 // This rewrites all routes requests to the root /index.html file
 // (ignoring file requests). If you want to implement universal


### PR DESCRIPTION
## Why is this change necessary?
* It cleans up some warnings that are occuring on a fresh install

## How does it address the issue?
* Adjust versions on dependencies so there are no unmet peer dependencies
* Increases the EventEmitter listeners to 100, in order to prevent the following warning from spamming the terminal:

```(node:27365) Warning: Possible EventEmitter memory leak detected. 11 error listeners added. Use emitter.setMaxListeners() to increase limit```

## What potential side effects does this change have?
* Increasing the EventEmitter listeners could have some side effects, but it doesn't appear to have a noticiable impact locally
