### PR TITLE
Updated default phantomjs port for karma test watching

### DIFF
--- a/build/karma.config.js
+++ b/build/karma.config.js
@@ -58,7 +58,8 @@ const karmaConfig = {
   },
   coverageReporter: {
     reporters: config.coverage_reporters
-  }
+  },
+  port: 9876
 }
 
 if (config.globals.__COVERAGE__) {


### PR DESCRIPTION
_Why_?

we were getting port collisions running this at the same time as the
webpack devserver

_How_?

set the default port for the karma web runner to be 9876

_Side Effects_?

no.