### PR TITLE
Updated test bundler to run universal context

### DIFF
--- a/build/karma.config.js
+++ b/build/karma.config.js
@@ -11,10 +11,11 @@ const karmaConfig = {
   files: [
     {
       pattern: `./${config.dir_test}/test-bundler.js`,
-      watched: false,
+      watched: true,
       served: true,
       included: true
     }
+
   ],
   singleRun: !argv.watch,
   frameworks: ['mocha'],

--- a/tests/test-bundler.js
+++ b/tests/test-bundler.js
@@ -17,25 +17,25 @@ global.sinon = sinon
 global.expect = chai.expect
 global.should = chai.should()
 
-// ---------------------------------------
-// Require Tests
-// ---------------------------------------
-// for use with karma-webpack-with-fast-source-maps
-// NOTE: `new Array()` is used rather than an array literal since
-// for some reason an array literal without a trailing `;` causes
-// some build environments to fail.
 const __karmaWebpackManifest__ = new Array() // eslint-disable-line
+
 const inManifest = (path) => ~__karmaWebpackManifest__.indexOf(path)
 
-// require all `tests/**/*.spec.js`
 const testsContext = require.context('./', true, /\.spec\.js$/)
+const universalContext = require.context('../universal', true, /\.spec\.js$/)
 
-// only run tests that have changed after the first pass.
-const testsToRun = testsContext.keys().filter(inManifest)
-;(testsToRun.length ? testsToRun : testsContext.keys()).forEach(testsContext)
+function runTests (context) {
+  const testsToRun = context.keys().filter(inManifest)
 
-// require all `universal/**/*.js` except for `main.js` (for isparta coverage reporting)
+  return (testsToRun.length ? testsToRun : context.keys()).forEach(context)
+}
+
+runTests(testsContext)
+runTests(universalContext)
+
 if (__COVERAGE__) {
-  const componentsContext = require.context('../universal/', true, /^((?!main|.stories).)*\.js$/)
+  const componentsContext = require.context(
+    '../universal/', true, /^((?!main|.stories).)*\.js$/
+  )
   componentsContext.keys().forEach(componentsContext)
 }

--- a/universal/containers/AppContainer.spec.js
+++ b/universal/containers/AppContainer.spec.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Provider } from 'react-redux'
+import { browserHistory } from 'react-router'
+import createStore from 'store/createStore'
+
+import { mount } from 'enzyme'
+import { expect } from 'chai'
+
+import AppContainer from 'containers/AppContainer'
+
+describe('<AppContainer />', () => {
+  it('Should render as a <Provider>.', () => {
+    const store = createStore({})
+
+    const wrapper = mount(<AppContainer store={store} history={browserHistory} />)
+
+    expect(wrapper.props().store).to.equal(store);
+  })
+})


### PR DESCRIPTION
_Why_?

* when autorunning the test suite, it wasn't picking up on the tests in
our universal codebase
* added a test for the appcontext
_How_?

* modified the test-bundler file to load multiple contexts and process
  the tests accordingly.
* specifically, we added the universal directory and created that
  context
* created a runTests method responsible for parsing the context and
  running the tests

_Side Effects_?

nope, just more tests!