### PR TITLE
port over counter test

### DIFF
--- a/universal/components/Counter/component.spec.js
+++ b/universal/components/Counter/component.spec.js
@@ -1,0 +1,15 @@
+import module from 'modules/Counter/module'
+
+const { actions, KEY } = module
+const { increment, doubleAsync } = actions
+
+describe('actions', () => {
+  it('should create an action to increment the counter by one', () => {
+    const expectedAction = {
+      type: 'counter/COUNTER_INCREMENT',
+      payload: 1
+    }
+
+    expect(increment()).toEqual(expectedAction)
+  })
+})


### PR DESCRIPTION
## Why is this change necessary?
* To keep the booster kit updated with relevant improvements

## How does it address the issue?
* It copies over a test written in the thrive-marketing repo

## What potential side effects does this change have?
* None

