### PR TITLE
update linter rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,7 @@
   "rules": {
     "semi" : [2, "never"],
     "max-len": [2, 120, 2],
+    "no-console": 2,
     "generator-star-spacing": 0,
     "babel/generator-star-spacing": 1
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf dist",
     "clean:project": "npm prune && npm cache clear && npm install",
     "compile": "better-npm-run compile",
-    "lint": "eslint bin build config server src tests",
+    "lint": "eslint bin build config server universal tests",
     "lint:fix": "npm run lint -- --fix",
     "start": "better-npm-run start",
     "dev": "better-npm-run dev",

--- a/universal/layouts/Home/component.js
+++ b/universal/layouts/Home/component.js
@@ -12,7 +12,7 @@ export const HomeView = () => (
     </div>
     <div className={styles.icon}>
       <p>If you don't see an icon below, something is wrong with icon fonts...</p>
-      <i className='icon-icon-mobile'></i>
+      <i className='icon-icon-mobile' />
     </div>
   </div>
 )


### PR DESCRIPTION
## Why is this change necessary?
* ```npm run lint``` wasn't linting the correct folders.

## How does it address the issue?
* It ports over the changes here: https://github.com/spartansystems/thrive-marketing/pull/37
* Adjusts the directories the lint action is using
* Fixes a linter violation

## What potential side effects does this change have?
* CircleCI should now run the correct linter rules

