### PR TITLE
changed proptypes in layoutcore because it was breaking as an array.

### DIFF
--- a/universal/layouts/LayoutCore/component.js
+++ b/universal/layouts/LayoutCore/component.js
@@ -22,7 +22,7 @@ export const LayoutCore = ({ children }) => (
 )
 
 LayoutCore.propTypes = {
-  children: React.PropTypes.element.isRequired
+  children: React.PropTypes.any.isRequired
 }
 
 export default LayoutCore


### PR DESCRIPTION
## Why is this change necessary?
* When using the booster the code climate score would significantly drop
* also @samcdavid said so

## How does it address the issue?
* updated layoutcore to have `any` instead of `array`

## What potential side effects does this change have?
* should work purrrfectly
